### PR TITLE
Add video download and processing tools to HeyGen MCP server

### DIFF
--- a/heygen_mcp/server.py
+++ b/heygen_mcp/server.py
@@ -3,9 +3,16 @@
 import argparse
 import os
 import sys
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Optional
+from datetime import datetime
 
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from mcp.server.models import Resource
+from mcp.server.models import Resource
 
 from heygen_mcp.api_client import (
     Character,
@@ -56,10 +63,10 @@ async def get_api_client() -> HeyGenApiClient:
 
 
 @mcp.tool(
-    name="get_remaining_credits",
-    description="Retrieves the remaining credits in heygen account.",
+    name="account_credits",
+    description="Retrieves the remaining credits in your HeyGen account.",
 )
-async def get_remaining_credits() -> MCPGetCreditsResponse:
+async def account_credits() -> MCPGetCreditsResponse:
     """Get the remaining quota for the user via HeyGen API."""
     try:
         client = await get_api_client()
@@ -69,13 +76,13 @@ async def get_remaining_credits() -> MCPGetCreditsResponse:
 
 
 @mcp.tool(
-    name="get_voices",
+    name="list_available_voices",
     description=(
         "Retrieves a list of available voices from the HeyGen API. Results truncated "
         "to first 100 voices. Private voices generally will returned 1st."
     ),
 )
-async def get_voices() -> MCPVoicesResponse:
+async def list_available_voices() -> MCPVoicesResponse:
     """Get the list of available voices via HeyGen API."""
     try:
         client = await get_api_client()
@@ -85,7 +92,7 @@ async def get_voices() -> MCPVoicesResponse:
 
 
 @mcp.tool(
-    name="get_avatar_groups",
+    name="list_avatar_groups",
     description=(
         "Retrieves a list of HeyGen avatar groups. By default, only private avatar "
         "groups are returned, unless include_public is set to true. Avatar groups "
@@ -93,7 +100,7 @@ async def get_voices() -> MCPVoicesResponse:
         "videos."
     ),
 )
-async def get_avatar_groups(include_public: bool = False) -> MCPAvatarGroupResponse:
+async def list_avatar_groups(include_public: bool = False) -> MCPAvatarGroupResponse:
     """List avatar groups via HeyGen API v2/avatar_group.list endpoint."""
     try:
         client = await get_api_client()
@@ -103,10 +110,10 @@ async def get_avatar_groups(include_public: bool = False) -> MCPAvatarGroupRespo
 
 
 @mcp.tool(
-    name="get_avatars_in_avatar_group",
+    name="list_avatars_in_group",
     description="Retrieves a list of avatars in a specific HeyGen avatar group.",
 )
-async def get_avatars_in_avatar_group(group_id: str) -> MCPAvatarsInGroupResponse:
+async def list_avatars_in_group(group_id: str) -> MCPAvatarsInGroupResponse:
     """List avatars in a specific HeyGen avatar group via HeyGen API."""
     try:
         client = await get_api_client()
@@ -116,11 +123,11 @@ async def get_avatars_in_avatar_group(group_id: str) -> MCPAvatarsInGroupRespons
 
 
 @mcp.tool(
-    name="generate_avatar_video",
-    description="Generates a new avatar video via the HeyGen API.",
+    name="create_video",
+    description="Step 1: Create a new avatar video with HeyGen API. Input text is required, avatar and voice are optional.",
 )
-async def generate_avatar_video(
-    avatar_id: str, input_text: str, voice_id: str, title: str = ""
+async def create_video(
+    input_text: str, avatar_id: Optional[str] = None, voice_id: Optional[str] = None, title: str = ""
 ) -> MCPVideoGenerateResponse:
     """Generate a new avatar video using the HeyGen API."""
     try:
@@ -143,21 +150,85 @@ async def generate_avatar_video(
 
 
 @mcp.tool(
-    name="get_avatar_video_status",
+    name="check_video_status",
     description=(
-        "Retrieves the status of a video generated via the HeyGen API. Video status "
-        "make take several minutes to hours depending on length of video and queue "
-        "time. If video is not yet complete, status be viewed later by user via "
-        "https://app.heygen.com/home"
+        "Step 2: Check the status of a video being generated. Video processing "
+        "may take several minutes to hours depending on length and queue time."
     ),
 )
-async def get_avatar_video_status(video_id: str) -> MCPVideoStatusResponse:
+async def check_video_status(video_id: str) -> MCPVideoStatusResponse:
     """Retrieve the status of a video generated via the HeyGen API."""
     try:
         client = await get_api_client()
         return await client.get_video_status(video_id)
     except Exception as e:
         return MCPVideoStatusResponse(error=str(e))
+
+
+@mcp.tool(
+    name="wait_for_video",
+    description=(
+        "Step 3: Wait for a video to complete processing. This tool will poll the "
+        "video status API until the video is complete or fails."
+    ),
+)
+async def wait_for_video(
+    video_id: str, max_attempts: int = 60, delay_seconds: int = 10
+) -> MCPVideoStatusResponse:
+    """Wait for a video to complete processing, polling the status endpoint."""
+    try:
+        client = await get_api_client()
+        return await client.wait_for_video_completion(video_id, max_attempts, delay_seconds)
+    except Exception as e:
+        return MCPVideoStatusResponse(error=str(e))
+
+
+@mcp.tool(
+    name="download_video",
+    description=(
+        "Step 4: Download a completed video to a local file and return the file "
+        "path and a resource link."
+    ),
+)
+async def download_video(video_id: str, download_path: Optional[str] = None) -> MCPVideoGenerateResponse:
+    """Download a completed video to a local file."""
+    try:
+        client = await get_api_client()
+        
+        # First get the current status to ensure we have the video URL
+        status = await client.get_video_status(video_id)
+        
+        if not status.video_url:
+            return MCPVideoGenerateResponse(
+                error="Video URL not available. Video may still be processing or failed."
+            )
+
+        # Generate a download path if not provided
+        if not download_path:
+            # Create temp dir if it doesn't exist
+            temp_dir = Path(tempfile.gettempdir()) / "heygen_videos"
+            temp_dir.mkdir(exist_ok=True)
+            
+            # Generate a filename using timestamp and video_id
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            download_path = str(temp_dir / f"{timestamp}_{video_id}.mp4")
+        
+        # Download the video
+        file_path = await client.download_video(status.video_url, download_path)
+        
+        # Create an MCP resource with the local file path
+        resource = Resource(file_path)
+        
+        # Return the download information
+        return MCPVideoGenerateResponse(
+            video_id=video_id,
+            status="downloaded",
+            video_url=status.video_url,
+            download_path=file_path,
+            resource=resource,
+        )
+    except Exception as e:
+        return MCPVideoGenerateResponse(error=str(e))
 
 
 def parse_args():
@@ -170,7 +241,9 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "--host", default="127.0.0.1", help="Host to bind the server to."
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the server to.",
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Port to bind the server to."


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the `heygen_mcp` module, focusing on improving API client functionality, adding new tools for video processing workflows, and renaming existing tools for better clarity. Key changes include making certain fields optional in data models, adding new methods for video downloading and status polling, and updating tool names and descriptions for consistency.

### Enhancements to API client functionality:
* Made `avatar_id` and `voice_id` fields optional in the `Character` and `Voice` models, respectively, allowing greater flexibility in video generation requests (`heygen_mcp/api_client.py`).
* Added `download_path` and `resource` fields to the `MCPVideoGenerateResponse` model to support video downloading and resource management (`heygen_mcp/api_client.py`).
* Introduced two new methods: `download_video` for downloading videos to local storage and `wait_for_video_completion` for polling video processing status until completion or failure (`heygen_mcp/api_client.py`).

### New tools for video processing workflows:
* Added `wait_for_video` as a tool to poll video status until completion and `download_video` to handle downloading completed videos, providing a streamlined workflow for video generation (`heygen_mcp/server.py`). (F93d0f71L160R241)

### Refactoring for clarity and consistency:
* Renamed several tools for better clarity, such as `get_remaining_credits` to `account_credits`, `get_voices` to `list_available_voices`, and `generate_avatar_video` to `create_video`. Updated their descriptions to reflect the changes (`heygen_mcp/server.py`). (F93d0f71L56R150)
* Updated tool names related to avatar groups, such as `get_avatar_groups` to `list_avatar_groups` and `get_avatars_in_avatar_group` to `list_avatars_in_group`, aligning with naming conventions (`heygen_mcp/server.py`). (F93d0f71L85R123)